### PR TITLE
Replaced all np.int and np.float with the respective 32-bit variants

### DIFF
--- a/eval/mot/motmetrics/distances.py
+++ b/eval/mot/motmetrics/distances.py
@@ -76,7 +76,7 @@ def boxiou(a, b):
     a_vol = np.prod(a_size, axis=-1)
     b_vol = np.prod(b_size, axis=-1)
     u_vol = a_vol + b_vol - i_vol
-    return np.where(i_vol == 0, np.zeros_like(i_vol, dtype=np.float),
+    return np.where(i_vol == 0, np.zeros_like(i_vol, dtype=np.float32),
                     math_util.quiet_divide(i_vol, u_vol))
 
 

--- a/eval/posetrack21/posetrack21/trackeval/datasets/posetrack.py
+++ b/eval/posetrack21/posetrack21/trackeval/datasets/posetrack.py
@@ -332,7 +332,7 @@ class PoseTrack(_BaseDataset):
             for t in range(raw_data['num_timesteps']):
                 if len(data['gt_ids'][t]) > 0:
                     data['original_gt_ids'][t] = data['gt_ids'][t].copy()
-                    data['gt_ids'][t] = gt_id_map[data['gt_ids'][t]].astype(np.int)
+                    data['gt_ids'][t] = gt_id_map[data['gt_ids'][t]].astype(np.int32)
 
                     gt_dets = data['gt_dets'][t]
                     num_gt_joints += count_valid_joints(gt_dets)
@@ -344,7 +344,7 @@ class PoseTrack(_BaseDataset):
             for t in range(raw_data['num_timesteps']):
                 if len(data['tracker_ids'][t]) > 0:
                     data['original_tracker_ids'][t] = data['tracker_ids'][t].copy()
-                    data['tracker_ids'][t] = tracker_id_map[data['tracker_ids'][t]].astype(np.int)
+                    data['tracker_ids'][t] = tracker_id_map[data['tracker_ids'][t]].astype(np.int32)
                     tracker_dets = data['tracker_dets'][t]
                     num_tracker_joints += count_valid_joints(tracker_dets)
 

--- a/eval/posetrack21/posetrack21/trackeval/datasets/posetrack_mot.py
+++ b/eval/posetrack21/posetrack21/trackeval/datasets/posetrack_mot.py
@@ -202,7 +202,7 @@ class PoseTrackMOT(_BaseDataset):
             time_key = str(t+1)
             if time_key in read_data.keys():
                 try:
-                    time_data = np.asarray(read_data[time_key], dtype=np.float)
+                    time_data = np.asarray(read_data[time_key], dtype=np.float32)
                 except ValueError:
                     if is_gt:
                         raise TrackEvalException(
@@ -330,7 +330,7 @@ class PoseTrackMOT(_BaseDataset):
 
             # Match tracker and gt dets (with hungarian algorithm) and remove tracker dets which match with gt dets
             # which are labeled as belonging to a distractor class.
-            to_remove_tracker = np.array([], np.int)
+            to_remove_tracker = np.array([], np.int32)
             if gt_ids.shape[0] > 0 and tracker_ids.shape[0] > 0:
 
                 # Check all classes are valid:
@@ -420,7 +420,7 @@ class PoseTrackMOT(_BaseDataset):
                                 det_idx = unmatched_det_idxs[remove_idx]
                                 dets_to_remove.append(det_idx)
                             
-                            to_remove_tracker = np.array(dets_to_remove, dtype=np.int)
+                            to_remove_tracker = np.array(dets_to_remove, dtype=np.int32)
                   
             # Apply preprocessing to remove all unwanted tracker dets.
             data['tracker_ids'][t] = np.delete(tracker_ids, to_remove_tracker, axis=0)
@@ -444,14 +444,14 @@ class PoseTrackMOT(_BaseDataset):
             gt_id_map[unique_gt_ids] = np.arange(len(unique_gt_ids))
             for t in range(raw_data['num_timesteps']):
                 if len(data['gt_ids'][t]) > 0:
-                    data['gt_ids'][t] = gt_id_map[data['gt_ids'][t]].astype(np.int)
+                    data['gt_ids'][t] = gt_id_map[data['gt_ids'][t]].astype(np.int32)
         if len(unique_tracker_ids) > 0:
             unique_tracker_ids = np.unique(unique_tracker_ids)
             tracker_id_map = np.nan * np.ones((np.max(unique_tracker_ids) + 1))
             tracker_id_map[unique_tracker_ids] = np.arange(len(unique_tracker_ids))
             for t in range(raw_data['num_timesteps']):
                 if len(data['tracker_ids'][t]) > 0:
-                    data['tracker_ids'][t] = tracker_id_map[data['tracker_ids'][t]].astype(np.int)
+                    data['tracker_ids'][t] = tracker_id_map[data['tracker_ids'][t]].astype(np.int32)
 
         # Record overview statistics.
         data['num_tracker_dets'] = num_tracker_dets

--- a/eval/posetrack21/posetrack21/trackeval/metrics/hota.py
+++ b/eval/posetrack21/posetrack21/trackeval/metrics/hota.py
@@ -31,20 +31,20 @@ class HOTA(_BaseMetric):
         # Initialise results
         res = {}
         for field in self.float_array_fields + self.integer_array_fields:
-            res[field] = np.zeros((len(self.array_labels)), dtype=np.float)
+            res[field] = np.zeros((len(self.array_labels)), dtype=np.float32)
         for field in self.float_fields:
             res[field] = 0
 
         # Return result quickly if tracker or gt sequence is empty
         if data['num_tracker_dets'] == 0:
-            res['HOTA_FN'] = data['num_gt_dets'] * np.ones((len(self.array_labels)), dtype=np.float)
-            res['LocA'] = np.ones((len(self.array_labels)), dtype=np.float)
+            res['HOTA_FN'] = data['num_gt_dets'] * np.ones((len(self.array_labels)), dtype=np.float32)
+            res['LocA'] = np.ones((len(self.array_labels)), dtype=np.float32)
             res['LocA(0)'] = 1.0
             res = self._compute_final_fields(res)
             return res
         if data['num_gt_dets'] == 0:
-            res['HOTA_FP'] = data['num_tracker_dets'] * np.ones((len(self.array_labels)), dtype=np.float)
-            res['LocA'] = np.ones((len(self.array_labels)), dtype=np.float)
+            res['HOTA_FP'] = data['num_tracker_dets'] * np.ones((len(self.array_labels)), dtype=np.float32)
+            res['LocA'] = np.ones((len(self.array_labels)), dtype=np.float32)
             res['LocA(0)'] = 1.0
             res = self._compute_final_fields(res)
             return res
@@ -343,9 +343,9 @@ class HOTA(_BaseMetric):
             vals.append("{0:1.5g}".format(100 * np.mean(result)))
         # we have an array for each joint
         elif metric in self.integer_array_fields:
-                vals.append("{0:d}".format(np.mean(result).astype(np.int)))
+                vals.append("{0:d}".format(np.mean(result).astype(np.int32)))
         elif metric in self.integer_fields:
-            vals.append("{0:d}".format(result.astype(np.int)))
+            vals.append("{0:d}".format(result.astype(np.int32)))
         else:
             raise TrackEvalException(f"Unknown metric {metric}")
 

--- a/eval/posetrack21/posetrack21/trackeval/metrics/hota_pose.py
+++ b/eval/posetrack21/posetrack21/trackeval/metrics/hota_pose.py
@@ -54,17 +54,17 @@ class HOTAeypoints(_BaseMetric):
         assert res['HOTA_TP'].shape[1] == 15 
         # Return result quickly if tracker or gt sequence is empty
         if data['num_tracker_dets'] == 0:
-            res['HOTA_FN'] = data['num_gt_joints'][None, :] * np.ones((len(self.array_labels), self.n_joints), dtype=np.float)
-            res['LocA'] = np.ones((len(self.array_labels), self.n_joints), dtype=np.float)
-            res['LocA(0)'] = np.ones((self.n_joints), dtype=np.float)
+            res['HOTA_FN'] = data['num_gt_joints'][None, :] * np.ones((len(self.array_labels), self.n_joints), dtype=np.float32)
+            res['LocA'] = np.ones((len(self.array_labels), self.n_joints), dtype=np.float32)
+            res['LocA(0)'] = np.ones((self.n_joints), dtype=np.float32)
             res = self._compute_final_fields(res, compute_avg=True)
 
             return res
 
         if data['num_gt_dets'] == 0:
-            res['HOTA_FP'] = data['num_tracker_joints'][None, :] * np.ones((len(self.array_labels), self.n_joints), dtype=np.float)
-            res['LocA'] = np.ones((len(self.array_labels), self.n_joints), dtype=np.float)
-            res['LocA(0)'] = np.ones((self.n_joints), dtype=np.float)
+            res['HOTA_FP'] = data['num_tracker_joints'][None, :] * np.ones((len(self.array_labels), self.n_joints), dtype=np.float32)
+            res['LocA'] = np.ones((len(self.array_labels), self.n_joints), dtype=np.float32)
+            res['LocA(0)'] = np.ones((self.n_joints), dtype=np.float32)
             res = self._compute_final_fields(res, compute_avg=True)
             return res
         
@@ -330,10 +330,10 @@ class HOTAeypoints(_BaseMetric):
         # we have an array for each joint
         elif metric in self.integer_array_fields:
             for j in range(result.shape[1]):
-                vals.append("{0:d}".format(np.mean(result[:, j]).astype(np.int)))
+                vals.append("{0:d}".format(np.mean(result[:, j]).astype(np.int32)))
         elif metric in self.integer_fields:
             for j in range(result.shape[0]):
-                vals.append("{0:d}".format(result[j].astype(np.int)))
+                vals.append("{0:d}".format(result[j].astype(np.int32)))
         else:
             raise TrackEvalException(f"Unknown metric {metric}")
 


### PR DESCRIPTION
Replaced all np.int and np.float with the corresponding 32 bit counterpart to allow compatibility with numpy > 1.20

See https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations for more details